### PR TITLE
readAll: added 'order by PKFIELD'

### DIFF
--- a/easydao-maven-plugin/src/main/resources/hu/vanio/easydao/templates/dao.ftl
+++ b/easydao-maven-plugin/src/main/resources/hu/vanio/easydao/templates/dao.ftl
@@ -81,7 +81,7 @@ public class ${t.javaName}${e.daoSuffix}Impl implements ${t.javaName}${e.daoSuff
 
     @Override
     public List<${t.javaName}> readAll(<#if t.hasBlobField || t.hasClobField>boolean readLobFields</#if>) {
-        String query = "select " + SELECTED_FIELDS + " from ${t.dbName} <#if t.hasPkField && !t.compositePk>order by ${t.pkField.dbName}</#if>";
+        String query = "select " + SELECTED_FIELDS + " from ${t.dbName}<#if t.hasPkField && !t.compositePk> order by ${t.pkField.dbName}</#if>";
         List<${t.javaName}> retVal = this.jdbcTemplate.query(query, new ${t.javaName}RowMapper(<#if t.hasBlobField || t.hasClobField>readLobFields</#if>));
         return retVal;
     }

--- a/easydao-maven-plugin/src/main/resources/hu/vanio/easydao/templates/dao.ftl
+++ b/easydao-maven-plugin/src/main/resources/hu/vanio/easydao/templates/dao.ftl
@@ -81,7 +81,7 @@ public class ${t.javaName}${e.daoSuffix}Impl implements ${t.javaName}${e.daoSuff
 
     @Override
     public List<${t.javaName}> readAll(<#if t.hasBlobField || t.hasClobField>boolean readLobFields</#if>) {
-        String query = "select " + SELECTED_FIELDS + " from ${t.dbName} order by ${t.pkField.dbName}";
+        String query = "select " + SELECTED_FIELDS + " from ${t.dbName} <#if t.hasPkField && !t.compositePk>order by ${t.pkField.dbName}</#if>";
         List<${t.javaName}> retVal = this.jdbcTemplate.query(query, new ${t.javaName}RowMapper(<#if t.hasBlobField || t.hasClobField>readLobFields</#if>));
         return retVal;
     }

--- a/easydao-maven-plugin/src/main/resources/hu/vanio/easydao/templates/dao.ftl
+++ b/easydao-maven-plugin/src/main/resources/hu/vanio/easydao/templates/dao.ftl
@@ -81,7 +81,7 @@ public class ${t.javaName}${e.daoSuffix}Impl implements ${t.javaName}${e.daoSuff
 
     @Override
     public List<${t.javaName}> readAll(<#if t.hasBlobField || t.hasClobField>boolean readLobFields</#if>) {
-        String query = "select " + SELECTED_FIELDS + " from ${t.dbName}";
+        String query = "select " + SELECTED_FIELDS + " from ${t.dbName} order by ${t.pkField.dbName}";
         List<${t.javaName}> retVal = this.jdbcTemplate.query(query, new ${t.javaName}RowMapper(<#if t.hasBlobField || t.hasClobField>readLobFields</#if>));
         return retVal;
     }


### PR DESCRIPTION
readAll reads all records without any order. Even this is a rarely used method, it may be a good idea to add an "order by" clause. It could be helpful using this method - especially in tests.